### PR TITLE
added destroy_plan and dropped destroy function

### DIFF
--- a/terrapy/plan.py
+++ b/terrapy/plan.py
@@ -41,7 +41,7 @@ class TerraformPlan(TerraformRun):
         self.modifications = 0
 
         self.changes = {}
-        for changeset in plan_details["resource_changes"]:
+        for changeset in plan_details.get("resource_changes", []):
             change = TerraformChange(changeset)
             self.changes[changeset["address"]] = TerraformChange(changeset)
             if change.will_delete():

--- a/terrapy/workspace.py
+++ b/terrapy/workspace.py
@@ -106,8 +106,19 @@ class TerraformWorkspace(TerraformRun):
             output_function=output_function,
         )
 
-    def destroy_plan(self, error_function=None, output_function=None, output_path=None):
-        return plan(self, error_function, output_function, output_path, destroy=True)
+    def destroy(self, auto_approve=False, error_function=None, output_function=None):
+        if not auto_approve:
+            return self.plan(
+                error_function=error_function,
+                output_function=output_function,
+                destroy=True
+            )
+        return self._subprocess_stream(
+            [self.terraform_path, "destroy", "-json", "-auto-approve"],
+            raise_exception_on_failure=True,  # TODO REVISIT
+            error_function=error_function,
+            output_function=output_function,
+        )
 
     def output(self):
         return self._subprocess_run([self.terraform_path, "output", "-json"])

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -39,12 +39,6 @@ def test_plan(workspace):
     assert isinstance(plan, TerraformPlan), "Terraform plan returned on successful plan."
 
 
-def test_destroy_plan(workspace):
-    results, plan = workspace.plan(error_function=print, output_function=print)
-    assert results.successful, "Terraform plan succeeded."
-    assert isinstance(plan, TerraformPlan), "Terraform plan returned on successfull plan."
-
-
 def test_apply_interaction(workspace):
     results = workspace.apply(error_function=print, output_function=print)
     assert results.returncode == 1, "Terraform apply failed when interaction is required."


### PR DESCRIPTION
- i added code cov
- dropped `destroy` and added `destroy_plan` ... this doesn't feel right, lmk if you think below is better

This feels smelly. Another way to do this would be to leave plan as is, leave the old `destroy` function (and turn auto_approve on in that one), but not use it ourselves right now