### PR TITLE
adjusted func param usage for error reporting

### DIFF
--- a/terrapyst/mixins.py
+++ b/terrapyst/mixins.py
@@ -36,7 +36,7 @@ class TerraformRun:
             error_message += f"returncode: {ret_results.returncode}\n"
             error_message += f"stdout: {ret_results.stdout}\n"
             error_message += f"stderr: {ret_results.stderr}\n"
-            raise TerraformRuntimeError(error_message)
+            raise TerraformRuntimeError(error_message, ret_results)
 
         return ret_results
 


### PR DESCRIPTION
i got this error and found it:

<img width="973" alt="image" src="https://user-images.githubusercontent.com/2961973/171445995-68cb1d70-1cd8-43b1-8cb3-e6d872e18be6.png">

i think it needs the process_results type arg