### PR TITLE
Save outputs directly instead of transforming them

### DIFF
--- a/terrapyst/apply_log.py
+++ b/terrapyst/apply_log.py
@@ -50,16 +50,10 @@ class TerraformApplyLog:
 
         # {"@level":"info","@message":"Outputs: 1","@module":"terraform.ui","@timestamp":"2022-08-11T09:59:00.389242-05:00","outputs":{"vpc":{"sensitive":false,"type":["object",{"arn":"string","assign_generated_ipv6_cidr_block":"bool","cidr_block":"string","default_network_acl_id":"string","default_route_table_id":"string","default_security_group_id":"string","dhcp_options_id":"string","enable_classiclink":"bool","enable_classiclink_dns_support":"bool","enable_dns_hostnames":"bool","enable_dns_support":"bool","id":"string","instance_tenancy":"string","ipv4_ipam_pool_id":"string","ipv4_netmask_length":"number","ipv6_association_id":"string","ipv6_cidr_block":"string","ipv6_cidr_block_network_border_group":"string","ipv6_ipam_pool_id":"string","ipv6_netmask_length":"number","main_route_table_id":"string","owner_id":"string","tags":["map","string"],"tags_all":["map","string"]}],"value":{"arn":"arn:aws:ec2:us-west-2:755842654594:vpc/vpc-010f9dfb4129daaca","assign_generated_ipv6_cidr_block":false,"cidr_block":"10.246.0.0/16","default_network_acl_id":"acl-0a5dd0254c60c41b0","default_route_table_id":"rtb-0b774b6dc44ee4bc8","default_security_group_id":"sg-0401f1cc7fdb04283","dhcp_options_id":"dopt-0e7128608c809b67b","enable_classiclink":false,"enable_classiclink_dns_support":false,"enable_dns_hostnames":true,"enable_dns_support":true,"id":"vpc-010f9dfb4129daaca","instance_tenancy":"default","ipv4_ipam_pool_id":null,"ipv4_netmask_length":null,"ipv6_association_id":"","ipv6_cidr_block":"","ipv6_cidr_block_network_border_group":"","ipv6_ipam_pool_id":"","ipv6_netmask_length":0,"main_route_table_id":"rtb-0b774b6dc44ee4bc8","owner_id":"755842654594","tags":{"Name":"test-246"},"tags_all":{"Name":"test-246"}}}},"type":"outputs"}
         if log["type"] == "outputs":
-            self.outputs = self.process_outputs(log["outputs"])
+            self.outputs = log["outputs"]
             return
 
         logger.warning(f"Apply log includes unknown type: {log['type']}")
-
-    def process_outputs(self, outputs: Dict[str, Any]) -> Dict[str, Any]:
-        return_outputs = {}
-        for key, output_object in outputs.items():
-            return_outputs[key] = {"sensitive": output_object["sensitive"], **output_object["value"]}
-        return outputs
 
     def process_resource(self, resource_log) -> None:
         if resource_log["type"] not in RESOURCE_TYPES:


### PR DESCRIPTION
This primarily leaves the "value" item where it is, instead of trying to flatten it. This is because I hadn't taken into account non-object values (you can't flatten a string).