### PR TITLE
fix: added guard for invalid json decode

### DIFF
--- a/terrapyst/apply_log.py
+++ b/terrapyst/apply_log.py
@@ -31,8 +31,13 @@ class TerraformApplyLog:
             self.add_line(log_line)
 
     def add_line(self, log_line: str) -> None:
-
-        log = json.loads(log_line)
+        log: Dict[str, Any]
+        try:
+            log = json.loads(log_line)
+        except json.decoder.JSONDecodeError:
+            # TODO - we should try to decode this in some other way
+            logger.warning(f"Apply log includes line of invalid json")
+            return
 
         if log["type"].startswith("refresh_"):
             return

--- a/tests/test_apply_logs.py
+++ b/tests/test_apply_logs.py
@@ -21,6 +21,13 @@ def test_read_log():
     assert "vpc" in apply_log.outputs
 
 
+def test_read_log_unreadable(caplog):
+    apply_log = TerraformApplyLog()
+    apply_log.add_lines("THIS WILL BE EMPTY\n")
+    assert apply_log.outputs == {}
+    assert "Apply log includes line of invalid json" in caplog.text
+
+
 def test_warning(caplog):
     apply_log = TerraformApplyLog()
     apply_log.add_lines(APPLY_LOG_CONTENTS)


### PR DESCRIPTION
## What does this do?

In some cases there are actually successful applications but at times there are non-json lines/json-decodable lines when terrapyst falsely crashes/errors because of a log line that is not json: 

```
  File "/usr/local/lib/python3.10/site-packages/terrapyst/workspace.py", line 115, in apply
    apply_log.add_lines(results.stdout)
  File "/usr/local/lib/python3.10/site-packages/terrapyst/apply_log.py", line 31, in add_lines
    self.add_line(log_line)
  File "/usr/local/lib/python3.10/site-packages/terrapyst/apply_log.py", line 35, in add_line
    log = json.loads(log_line)
  File "/usr/local/lib/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/local/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
",
```

This is likely because the apply log log lines are getting non-json in some cases

## References

* [Link to Shortcut](https://app.shortcut.com/aptible/story/7291/terrapyst-errors-on-some-success-messages-occurred-on-a-successful-ecs-deploy)
* Links to Slab, Slack, Zendesk, etc

## Screenshots

~This section is especially important for user-facing changes or changes that impact DX, but also can be used for proof of manual testing.~

## Security

Are there any security implications of this change? If so, explain them here.

Yes. I am currently omitting this from being logged, as we may need to process the text for any sensitive values. I do not have an example sensitive value that is causing this decoder to fail. I'm trying to move this along and will create a subsequent ticket to investigate/filter the body of this value in testing.

## Testing

~If you didn't write automated tests, you **MUST** explain why.~

~If you didn't manually test, you **MUST** explain why. ~

## Deployment

Are there any dependencies, timing concerns, or other constraints that might impact deployment? 

N/A
